### PR TITLE
Release 1 — Cleanup: the 10 milestone bug fixes

### DIFF
--- a/frontend/app/exercise-library.tsx
+++ b/frontend/app/exercise-library.tsx
@@ -67,7 +67,12 @@ export default function ExerciseLibrary() {
   const [filter, setFilter] = useState<string>(ALL);
   const [categories, setCategories] = useState<CategoryOut[]>([]);
   const [exercises, setExercises] = useState<ExerciseOut[]>([]);
-  const [selected, setSelected] = useState<Set<string>>(new Set());
+  // Keyed by exercise id, holding the whole `ExerciseOut`. Storing the objects
+  // (not just ids) is what lets a pick made under an earlier search survive:
+  // `exercises` is the *filtered* result set, so a later query drops the row a
+  // selection was made from and an id-only set could no longer resolve it.
+  // Insertion order is the add order.
+  const [selected, setSelected] = useState<Map<string, ExerciseOut>>(new Map());
   const [loading, setLoading] = useState(false);
   const [adding, setAdding] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -148,11 +153,11 @@ export default function ExerciseLibrary() {
   // left the field looking inert while typing.
   const searching = loading || query.trim() !== debouncedQuery;
 
-  const toggle = useCallback((id: string) => {
+  const toggle = useCallback((ex: ExerciseOut) => {
     setSelected((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
+      const next = new Map(prev);
+      if (next.has(ex.id)) next.delete(ex.id);
+      else next.set(ex.id, ex);
       return next;
     });
   }, []);
@@ -166,12 +171,7 @@ export default function ExerciseLibrary() {
     }
     if (pickMode) {
       // Return the selected ExerciseOut list to whoever opened us (e.g. routine builder).
-      const chosen: ExerciseOut[] = [];
-      for (const id of selected) {
-        const ex = exercises.find((e) => e.id === id);
-        if (ex) chosen.push(ex);
-      }
-      setPendingSelection(chosen);
+      setPendingSelection([...selected.values()]);
       router.back();
       return;
     }
@@ -183,7 +183,7 @@ export default function ExerciseLibrary() {
     setAdding(true);
     try {
       // Sequential POSTs — server assigns position in order.
-      for (const id of selected) {
+      for (const id of selected.keys()) {
         await addWorkoutExercise(workoutId, {
           exercise_id: id,
           rest_seconds: DEFAULT_REST_SECONDS,
@@ -244,7 +244,7 @@ export default function ExerciseLibrary() {
                     exercise={ex}
                     selected={sel}
                     selectable={!browseMode}
-                    onToggle={() => toggle(ex.id)}
+                    onToggle={() => toggle(ex)}
                   />
                 );
               })}

--- a/frontend/app/routine/[id].tsx
+++ b/frontend/app/routine/[id].tsx
@@ -38,6 +38,7 @@ import {
   TrashIcon,
 } from '../../src/components/icons';
 import { RestPickerSheet } from '../../src/components/workout/RestPickerSheet';
+import { SwipeToDelete } from '../../src/components/workout/SwipeToDelete';
 import {
   restLabel,
   TYPE_CYCLE,
@@ -95,6 +96,8 @@ export default function RoutineBuilder() {
   const [loading, setLoading] = useState(!isNew);
   const [saving, setSaving] = useState(false);
   const [restSheetExId, setRestSheetExId] = useState<string | null>(null);
+  /** Set row whose swipe-to-delete panel is revealed — at most one at a time. */
+  const [openSetId, setOpenSetId] = useState<string | null>(null);
 
   // Load existing routine (edit mode).
   useEffect(() => {
@@ -214,6 +217,21 @@ export default function RoutineBuilder() {
       ),
     );
 
+  /**
+   * Remove one planned set. No confirmation — the swipe-open + Delete tap is
+   * already deliberate, matching the active-workout screen's `deleteSet`.
+   * Removing the last set is allowed: an exercise with no sets is a valid
+   * (if unusual) routine, and "+ Add Set" is right there to undo it.
+   */
+  const removeSet = (rexId: string, setId: string) => {
+    setOpenSetId(null);
+    setExercises((prev) =>
+      prev.map((e) =>
+        e.id !== rexId ? e : { ...e, sets: e.sets.filter((s) => s.id !== setId) },
+      ),
+    );
+  };
+
   const patchSet = (rexId: string, setId: string, patch: Partial<RSet>) =>
     setExercises((prev) =>
       prev.map((e) =>
@@ -320,6 +338,9 @@ export default function RoutineBuilder() {
                   onNoteChange={(t) => setNote(rex.id, t)}
                   onOpenRest={() => setRestSheetExId(rex.id)}
                   onAddSet={() => addSet(rex.id)}
+                  onRemoveSet={(setId) => removeSet(rex.id, setId)}
+                  openSetId={openSetId}
+                  onSetOpenChange={(setId, open) => setOpenSetId(open ? setId : null)}
                   onCycleType={(setId) => cycleType(rex.id, setId)}
                   onWeightChange={(setId, t) =>
                     patchSet(rex.id, setId, { targetWeight: t })
@@ -398,6 +419,9 @@ function ExerciseCardBuilder({
   onNoteChange,
   onOpenRest,
   onAddSet,
+  onRemoveSet,
+  openSetId,
+  onSetOpenChange,
   onCycleType,
   onWeightChange,
   onRepsChange,
@@ -408,6 +432,9 @@ function ExerciseCardBuilder({
   onNoteChange: (t: string) => void;
   onOpenRest: () => void;
   onAddSet: () => void;
+  onRemoveSet: (setId: string) => void;
+  openSetId: string | null;
+  onSetOpenChange: (setId: string, open: boolean) => void;
   onCycleType: (setId: string) => void;
   onWeightChange: (setId: string, t: string) => void;
   onRepsChange: (setId: string, t: string) => void;
@@ -495,7 +522,15 @@ function ExerciseCardBuilder({
 
           const meta = typeMeta[s.type];
           return (
-            <View key={s.id} style={styles.setRow}>
+            <SwipeToDelete
+              key={s.id}
+              onDelete={() => onRemoveSet(s.id)}
+              isOpen={openSetId === s.id}
+              onOpenChange={(open) => onSetOpenChange(s.id, open)}
+              accessibilityLabel={`Delete set ${badge}`}
+              radius={9}
+              rowStyle={styles.setRow}
+            >
               <View style={styles.colSet}>
                 <Pressable
                   onPress={() => onCycleType(s.id)}
@@ -531,7 +566,7 @@ function ExerciseCardBuilder({
                   style={styles.numInput}
                 />
               </View>
-            </View>
+            </SwipeToDelete>
           );
         })}
       </View>
@@ -800,6 +835,9 @@ const styles = StyleSheet.create({
     paddingVertical: 4,
     height: 46,
     borderRadius: 9,
+    // Opaque (same tone as the card it sits on) so the swipe-revealed delete
+    // panel stays hidden behind the row until it slides away.
+    backgroundColor: color.surface1,
   },
   badge: {
     width: 30,

--- a/frontend/app/routine/[id].tsx
+++ b/frontend/app/routine/[id].tsx
@@ -98,6 +98,9 @@ export default function RoutineBuilder() {
   const [restSheetExId, setRestSheetExId] = useState<string | null>(null);
   /** Set row whose swipe-to-delete panel is revealed — at most one at a time. */
   const [openSetId, setOpenSetId] = useState<string | null>(null);
+  /** Set once Save was tapped with a blank name, so the requirement is explained. */
+  const [nameMissing, setNameMissing] = useState(false);
+  const nameRef = useRef<TextInput>(null);
 
   // Load existing routine (edit mode).
   useEffect(() => {
@@ -268,7 +271,15 @@ export default function RoutineBuilder() {
   const canSave = name.trim() !== '';
 
   const onSave = async () => {
-    if (!canSave || saving) return;
+    if (saving) return;
+    // Save stays tappable when the name is blank: a dimmed, inert button gave no
+    // clue that a name was the thing standing in the way. Tapping it now says so
+    // and puts the cursor in the field.
+    if (!canSave) {
+      setNameMissing(true);
+      nameRef.current?.focus();
+      return;
+    }
     setSaving(true);
     try {
       const payload = buildPayload();
@@ -311,13 +322,21 @@ export default function RoutineBuilder() {
           showsVerticalScrollIndicator={false}
         >
           <TextInput
+            ref={nameRef}
             value={name}
-            onChangeText={setName}
+            onChangeText={(t) => {
+              setName(t);
+              if (t.trim() !== '') setNameMissing(false);
+            }}
             placeholder="Routine name"
-            placeholderTextColor={color.text3}
+            placeholderTextColor={nameMissing ? color.error : color.text3}
             style={styles.titleInput}
             multiline
           />
+
+          {nameMissing ? (
+            <Text style={styles.nameError}>Give your routine a name to save it.</Text>
+          ) : null}
 
           <View style={styles.metaRow}>
             <Text style={styles.metaText}>{exercises.length} exercises</Text>
@@ -376,9 +395,8 @@ export default function RoutineBuilder() {
         </Text>
         <Pressable
           onPress={onSave}
-          disabled={!canSave || saving}
+          disabled={saving}
           hitSlop={8}
-          pointerEvents={!canSave ? 'none' : 'auto'}
           style={[styles.saveBtn, (!canSave || saving) && { opacity: 0.5 }]}
         >
           <Text style={styles.saveText}>Save</Text>
@@ -646,6 +664,13 @@ const styles = StyleSheet.create({
     letterSpacing: -0.52,
     paddingHorizontal: 2,
     paddingVertical: 0,
+  },
+  nameError: {
+    fontFamily: font.monoRegular,
+    fontSize: 12,
+    color: color.error,
+    marginTop: 8,
+    marginHorizontal: 2,
   },
   metaRow: {
     flexDirection: 'row',

--- a/frontend/app/workout/[id].tsx
+++ b/frontend/app/workout/[id].tsx
@@ -171,6 +171,9 @@ export default function ActiveWorkout() {
   // they change only when rest starts, is adjusted, or ends — never on the tick.
   const [restStartedAt, setRestStartedAt] = useState<number | null>(null);
   const [restEndsAt, setRestEndsAt] = useState<number | null>(null);
+  // Which exercise's rest is running, so changing that exercise's duration can
+  // retime it. `null` for a manually-started rest, which belongs to no exercise.
+  const [restExId, setRestExId] = useState<string | null>(null);
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
   const [restSheetExId, setRestSheetExId] = useState<string | null>(null);
   const [reordering, setReordering] = useState(false);
@@ -385,6 +388,7 @@ export default function ActiveWorkout() {
     if (restRemaining === 0 && restEndsAt != null) {
       setRestStartedAt(null);
       setRestEndsAt(null);
+      setRestExId(null);
     }
   }, [restRemaining, restEndsAt]);
 
@@ -470,9 +474,7 @@ export default function ActiveWorkout() {
       endRest();
       return;
     }
-    setRestRemaining((r) => Math.max(0, r + action.seconds));
-    setRestEndsAt((e) => (e == null ? e : Math.max(Date.now(), e + action.seconds * 1000)));
-    if (action.seconds > 0) setRestTotal((t) => Math.max(t, restRemaining + action.seconds));
+    adjustRest(action.seconds);
   };
 
   // Held in refs: these listeners are registered once and must not close over a
@@ -487,11 +489,11 @@ export default function ActiveWorkout() {
     // does. Refetch FIRST: our state still shows the set as undone, so naming
     // the "next" exercise before the write lands picks the wrong one — and the
     // set itself would keep rendering unchecked.
-    const offChange = onWorkoutChanged(async (restSeconds) => {
+    const offChange = onWorkoutChanged(async (rest) => {
       await refreshRef.current();
       // The refetch has landed, so the completed set is already `done` — the
       // plain look-ahead is enough here.
-      startRest(restSeconds, upcomingExerciseName());
+      startRest(rest.seconds, upcomingExerciseName(), rest.exerciseId);
     });
 
     // The event can land while this screen is unmounted (a background launch),
@@ -568,14 +570,42 @@ export default function ActiveWorkout() {
   const upcomingExerciseName = (justCompleted?: string): string | null =>
     locateNextSet(exercisesRef.current, justCompleted)?.exercise.name ?? null;
 
-  const startRest = (seconds: number, exerciseName: string | null = null) => {
+  const startRest = (
+    seconds: number,
+    exerciseName: string | null = null,
+    exerciseId: string | null = null,
+  ) => {
     if (seconds <= 0) return;
     const now = Date.now();
     setRestTotal(seconds);
     setRestRemaining(seconds);
     setRestStartedAt(now);
     setRestEndsAt(now + seconds * 1000);
+    setRestExId(exerciseId);
+    restEndsRef.current = now + seconds * 1000;
     armRestAlert(seconds, exerciseName);
+  };
+
+  /**
+   * Nudge the running rest by ±seconds. One place, because three surfaces do it
+   * (the in-app ±15, the Lock Screen card's, the Watch's) and every one of them
+   * also has to re-arm the scheduled alert — a countdown that moved with an
+   * alert that didn't buzzes at the old moment.
+   *
+   * `restEndsRef` is written straight away so a drain of several queued card
+   * taps in one tick composes instead of all reading the same pre-tick end.
+   */
+  const adjustRest = (deltaSeconds: number) => {
+    const end = restEndsRef.current;
+    if (end == null) return;
+    const now = Date.now();
+    const endsAt = Math.max(now, end + deltaSeconds * 1000);
+    restEndsRef.current = endsAt;
+    const remaining = restRemainingSeconds(endsAt, now);
+    setRestEndsAt(endsAt);
+    setRestRemaining(remaining);
+    if (deltaSeconds > 0) setRestTotal((t) => Math.max(t, remaining));
+    armRestAlert(remaining, upcomingExerciseName());
   };
 
   // Ending rest early (Skip, or trimming it to zero) must also cancel the
@@ -587,6 +617,8 @@ export default function ActiveWorkout() {
     setRestRemaining(0);
     setRestStartedAt(null);
     setRestEndsAt(null);
+    setRestExId(null);
+    restEndsRef.current = null;
     const pending = restAlertId.current;
     restAlertId.current = null;
     void cancelRestAlert(pending);
@@ -615,7 +647,7 @@ export default function ActiveWorkout() {
     // what is *coming* — which, after an exercise's last set, is the next
     // exercise. `exercises` has not re-rendered yet, so the set being completed
     // is passed as `treatAsDone`.
-    if (willBeDone) startRest(ex.rest, upcomingExerciseName(setId));
+    if (willBeDone) startRest(ex.rest, upcomingExerciseName(setId), ex.id);
     if (persist) write(patchSetApi(setId, { done: willBeDone }));
   };
 
@@ -792,8 +824,29 @@ export default function ActiveWorkout() {
     ]);
   };
 
-  const setRest = (exId: string, seconds: number) =>
+  const setRest = (exId: string, seconds: number) => {
     setExercises((prev) => prev.map((ex) => (ex.id === exId ? { ...ex, rest: seconds } : ex)));
+
+    // A rest already counting down for this exercise adopts the new duration
+    // now, rather than only on the next set. Re-anchored on when the rest
+    // started, so the part already served still counts: 30s into a 2:00 rest,
+    // switching to 3:00 leaves 2:30 — not a fresh 3:00.
+    if (restExId !== exId || restStartedAt == null) return;
+    const now = Date.now();
+    const endsAt = restStartedAt + seconds * 1000;
+    // The new duration is already spent (or the picker's "Off") — the rest is
+    // simply over, and endRest cancels the alert that was scheduled for it.
+    if (endsAt <= now) {
+      endRest();
+      return;
+    }
+    const remaining = restRemainingSeconds(endsAt, now);
+    setRestTotal(seconds);
+    setRestEndsAt(endsAt);
+    setRestRemaining(remaining);
+    restEndsRef.current = endsAt;
+    armRestAlert(remaining, upcomingExerciseName());
+  };
 
   const onFinish = async () => {
     // Not on unmount: leaving the screen with the workout still running is
@@ -868,13 +921,11 @@ export default function ActiveWorkout() {
             }),
           );
         }
-        if (ex) startRest(ex.rest, upcomingExerciseName(st.currentSetId));
+        if (ex) startRest(ex.rest, upcomingExerciseName(st.currentSetId), ex.id);
         break;
       }
       case 'adjustRest':
-        setRestRemaining((r) => Math.max(0, r + a.seconds));
-        setRestEndsAt((e) => (e == null ? e : Math.max(Date.now(), e + a.seconds * 1000)));
-        if (a.seconds > 0) setRestTotal((t) => Math.max(t, restRemaining + a.seconds));
+        adjustRest(a.seconds);
         break;
       case 'skipRest':
         endRest();
@@ -1029,15 +1080,8 @@ export default function ActiveWorkout() {
         remaining={restRemaining}
         total={restTotal}
         onStart={() => startRest(DEFAULT_REST)}
-        onMinus15={() => {
-          setRestRemaining((r) => Math.max(0, r - 15));
-          setRestEndsAt((e) => (e == null ? e : Math.max(Date.now(), e - 15_000)));
-        }}
-        onPlus15={() => {
-          setRestRemaining((r) => r + 15);
-          setRestTotal((t) => Math.max(t, restRemaining + 15));
-          setRestEndsAt((e) => (e == null ? e : e + 15_000));
-        }}
+        onMinus15={() => adjustRest(-15)}
+        onPlus15={() => adjustRest(15)}
         onSkip={endRest}
       />
 

--- a/frontend/app/workout/[id].tsx
+++ b/frontend/app/workout/[id].tsx
@@ -46,6 +46,7 @@ import {
 import { takePendingSelection } from '../../src/lib/pendingSelection';
 import { replaceOrder, swapExercise } from '../../src/lib/replaceExercise';
 import { elapsedSeconds, restRemainingSeconds } from '../../src/lib/clocks';
+import { locateNextSet } from '../../src/lib/nextSet';
 import { parseServerDate } from '../../src/lib/serverTime';
 import {
   forgetActiveWorkout,
@@ -488,8 +489,9 @@ export default function ActiveWorkout() {
     // set itself would keep rendering unchecked.
     const offChange = onWorkoutChanged(async (restSeconds) => {
       await refreshRef.current();
-      const ex = exercisesRef.current.find((e) => e.sets.some((s) => !s.done));
-      startRest(restSeconds, ex?.name ?? null);
+      // The refetch has landed, so the completed set is already `done` — the
+      // plain look-ahead is enough here.
+      startRest(restSeconds, upcomingExerciseName());
     });
 
     // The event can land while this screen is unmounted (a background launch),
@@ -558,6 +560,14 @@ export default function ActiveWorkout() {
     });
   };
 
+  /**
+   * Name of the exercise the *next* set belongs to — what the end-of-rest alert
+   * announces. `justCompleted` is skipped as though already done, so this can be
+   * called before `setExercises` has re-rendered. `null` once nothing is left.
+   */
+  const upcomingExerciseName = (justCompleted?: string): string | null =>
+    locateNextSet(exercisesRef.current, justCompleted)?.exercise.name ?? null;
+
   const startRest = (seconds: number, exerciseName: string | null = null) => {
     if (seconds <= 0) return;
     const now = Date.now();
@@ -601,7 +611,11 @@ export default function ActiveWorkout() {
     }
 
     patchSet(exId, setId, { done: willBeDone });
-    if (willBeDone) startRest(ex.rest, ex.name);
+    // The rest belongs to the exercise just finished, but the alert announces
+    // what is *coming* — which, after an exercise's last set, is the next
+    // exercise. `exercises` has not re-rendered yet, so the set being completed
+    // is passed as `treatAsDone`.
+    if (willBeDone) startRest(ex.rest, upcomingExerciseName(setId));
     if (persist) write(patchSetApi(setId, { done: willBeDone }));
   };
 
@@ -854,7 +868,7 @@ export default function ActiveWorkout() {
             }),
           );
         }
-        if (ex) startRest(ex.rest, ex.name);
+        if (ex) startRest(ex.rest, upcomingExerciseName(st.currentSetId));
         break;
       }
       case 'adjustRest':

--- a/frontend/app/workout/[id].tsx
+++ b/frontend/app/workout/[id].tsx
@@ -11,6 +11,7 @@ import {
   AppState,
   Keyboard,
   KeyboardAvoidingView,
+  Linking,
   Platform,
   Pressable,
   ScrollView,
@@ -47,6 +48,11 @@ import { takePendingSelection } from '../../src/lib/pendingSelection';
 import { replaceOrder, swapExercise } from '../../src/lib/replaceExercise';
 import { elapsedSeconds, restRemainingSeconds } from '../../src/lib/clocks';
 import { locateNextSet } from '../../src/lib/nextSet';
+import {
+  forgetLiveActivityHint,
+  liveActivityHintShown,
+  rememberLiveActivityHint,
+} from '../../src/lib/liveActivityHint';
 import { parseServerDate } from '../../src/lib/serverTime';
 import {
   forgetActiveWorkout,
@@ -444,14 +450,49 @@ export default function ActiveWorkout() {
     // it in the deps the card would never start.
   }, [liveActivity, restStartedAt, restEndsAt, startedAt]);
 
+  /**
+   * Say once, at the start of a workout, when Live Activities are switched off
+   * for Ischys — iOS does that by itself after a card is dismissed, `start()`
+   * then quietly returns nil, and nothing else in the app reveals why the Lock
+   * Screen stayed empty (#29). `isAvailable()` keeps this to the case the user
+   * can actually act on: an iPhone too old for Live Activities gets no hint.
+   */
+  const liveActivityChecked = useRef(false);
+  useEffect(() => {
+    if (!liveActivity || liveActivityChecked.current) return;
+    if (!LiveActivity.isAvailable()) return;
+    liveActivityChecked.current = true;
+
+    if (LiveActivity.isSupported()) {
+      // On: re-arm, so a future switch-off earns one fresh reminder.
+      forgetLiveActivityHint();
+      return;
+    }
+    if (liveActivityHintShown()) return;
+    rememberLiveActivityHint();
+    Alert.alert(
+      'Live Activities are off',
+      'Turn on Live Activities for Ischys in Settings to see your rest timer on the Lock Screen.',
+      [
+        { text: 'Not now', style: 'cancel' },
+        { text: 'Open Settings', onPress: () => void Linking.openSettings().catch(() => {}) },
+      ],
+    );
+  }, [liveActivity]);
+
   // Re-show the Live Activity if the user swiped it away. iOS ends a dismissed
   // card but we still think it runs, so on return to foreground we ask the
   // native side whether one is actually live and restart it if not — as long as
   // the workout still has something to show.
+  //
+  // The `isSupported` check is inside the listener, not around it: coming back
+  // from Settings having just switched Live Activities back on IS a foreground
+  // transition, and a check outside would have been made while they were still
+  // off and would have skipped registering entirely.
   useEffect(() => {
-    if (!LiveActivity.isSupported()) return;
     const sub = AppState.addEventListener('change', (s) => {
       if (s !== 'active') return;
+      if (!LiveActivity.isSupported()) return;
       if (!liveActivity || startedAtRef.current == null) return;
       if (LiveActivity.isActive()) return;
       const state = {

--- a/frontend/app/workout/[id].tsx
+++ b/frontend/app/workout/[id].tsx
@@ -927,8 +927,9 @@ export default function ActiveWorkout() {
         name || 'Workout',
         { resting: restRemaining > 0, remaining: restRemaining, total: restTotal },
         (sets, i) => resolveSet(sets[i], carryFor(sets, i)),
+        startedAt,
       ),
-    [exercises, name, restRemaining, restTotal],
+    [exercises, name, restRemaining, restTotal, startedAt],
   );
   const watchStateRef = useRef(watchState);
   watchStateRef.current = watchState;

--- a/frontend/modules/health/index.ts
+++ b/frontend/modules/health/index.ts
@@ -12,6 +12,7 @@ type HealthNativeModule = {
   requestAuthorization(): Promise<boolean>;
   /** `startedAt`/`endedAt` are epoch ms; `energyKcal` 0 to attach no energy. */
   saveWorkout(startedAt: number, endedAt: number, energyKcal: number): Promise<boolean>;
+  hasWorkout(startedAt: number, endedAt: number): Promise<boolean>;
   readWorkoutMetrics(startedAt: number, endedAt: number): Promise<WorkoutMetrics>;
   startHeartRateUpdates(): void;
   stopHeartRateUpdates(): void;
@@ -48,6 +49,23 @@ export const saveWorkout = async (
   endedAt: number,
   energyKcal = 0,
 ): Promise<boolean> => (native ? native.saveWorkout(startedAt, endedAt, energyKcal) : false);
+
+/**
+ * Whether Ischys — the phone app or its Watch companion — has already written a
+ * strength HKWorkout covering this window. The phone checks before writing a
+ * workout the Watch may have saved without its confirmation arriving in time.
+ *
+ * False on an older native module that lacks the query, which just restores the
+ * previous behaviour: write and risk the duplicate rather than lose the workout.
+ */
+export const hasWorkout = async (startedAt: number, endedAt: number): Promise<boolean> => {
+  if (!native || typeof native.hasWorkout !== 'function') return false;
+  try {
+    return await native.hasWorkout(startedAt, endedAt);
+  } catch {
+    return false;
+  }
+};
 
 /** Avg/max HR and energy a Watch recorded for [startedAt, endedAt]. */
 export const readWorkoutMetrics = async (

--- a/frontend/modules/health/ios/HealthModule.swift
+++ b/frontend/modules/health/ios/HealthModule.swift
@@ -125,6 +125,70 @@ public class HealthModule: Module {
       }
     }
 
+    /// Whether Ischys has ALREADY put a strength HKWorkout over [startMs, endMs].
+    ///
+    /// The Watch is the primary writer when it recorded the session, and it
+    /// confirms the save over WatchConnectivity so the phone knows to stand down.
+    /// That confirmation is not reliable enough to be the only signal: with the
+    /// phone app not frontmost it falls back to `transferUserInfo`, which is
+    /// queued for the phone's next run — long after the phone has given up
+    /// waiting and written its own copy. Asking HealthKit is authoritative.
+    ///
+    /// Only workouts written by Ischys count. Another app's strength session
+    /// overlapping this window must not make us drop the user's workout, so the
+    /// source is matched against our own bundle id — with a prefix, because the
+    /// Watch companion's id is the phone app's plus a suffix and either half of
+    /// the pair may have been the writer.
+    AsyncFunction("hasWorkout") { (startMs: Double, endMs: Double, promise: Promise) in
+      guard HKHealthStore.isHealthDataAvailable() else {
+        promise.resolve(false)
+        return
+      }
+      let ours = Bundle.main.bundleIdentifier ?? ""
+      guard !ours.isEmpty else {
+        promise.resolve(false)
+        return
+      }
+      let start = Date(timeIntervalSince1970: startMs / 1000)
+      let end = Date(timeIntervalSince1970: endMs / 1000)
+
+      // Overlap, not containment: the Watch's session begins a moment after the
+      // workout does and its HKWorkout is stamped from the session, so a strict
+      // match would miss exactly the copy we are looking for.
+      let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+        HKQuery.predicateForSamples(withStart: start, end: end, options: []),
+        HKQuery.predicateForWorkouts(with: .traditionalStrengthTraining),
+      ])
+
+      let query = HKSampleQuery(
+        sampleType: HKObjectType.workoutType(),
+        predicate: predicate,
+        limit: HKObjectQueryNoLimit,
+        sortDescriptors: nil
+      ) { _, samples, _ in
+        // A query error (including workout-read access being denied, which
+        // HealthKit reports as no data rather than an error) resolves false, so
+        // the caller writes. Erring toward a rare duplicate beats losing a
+        // finished workout.
+        let sessionLength = end.timeIntervalSince(start)
+        let found = (samples ?? []).contains { sample in
+          let id = sample.sourceRevision.source.bundleIdentifier
+          guard id == ours || id.hasPrefix(ours + ".") else { return false }
+
+          // Back-to-back sessions touch at an endpoint and would otherwise match
+          // on overlap alone, suppressing a workout that is genuinely new. A
+          // real duplicate covers most of both intervals, so require that of it.
+          let overlap = min(end, sample.endDate)
+            .timeIntervalSince(max(start, sample.startDate))
+          guard overlap > 0 else { return false }
+          let sampleLength = sample.endDate.timeIntervalSince(sample.startDate)
+          return overlap >= sampleLength / 2 && overlap >= sessionLength / 2
+        }
+        promise.resolve(found)
+      }
+      self.store.execute(query)
+    }
+
     /// Aggregates for a finished workout: average and max heart rate (bpm) and
     /// total active energy (kcal) over [startMs, endMs]. Any field is null when
     /// HealthKit holds no samples for it — i.e. no Watch was recording.

--- a/frontend/modules/live-activity/index.ts
+++ b/frontend/modules/live-activity/index.ts
@@ -39,6 +39,7 @@ export type LiveActivityAction =
 
 type LiveActivityNativeModule = {
   isSupported(): boolean;
+  isAvailable(): boolean;
   isActive(): boolean;
   start(workoutStartedAt: number, state: LiveActivityState): string | null;
   update(state: LiveActivityState): Promise<void>;
@@ -49,9 +50,29 @@ type LiveActivityNativeModule = {
 
 const native = requireOptionalNativeModule<LiveActivityNativeModule>('LiveActivity');
 
-/** Live Activities are iOS-only; every call is a no-op elsewhere. */
+/**
+ * Live Activities are iOS-only; every call is a no-op elsewhere.
+ *
+ * False *either* because the OS cannot show them or because the user has them
+ * switched off for Ischys — see `isAvailable` for telling those two apart.
+ */
 export const isSupported = (): boolean =>
   Platform.OS === 'ios' && !!native && native.isSupported();
+
+/**
+ * The OS can show Live Activities, whatever the per-app switch says. So
+ * `isAvailable() && !isSupported()` means precisely "turned off for Ischys" —
+ * the one case worth telling the user about, because iOS turns the switch off
+ * by itself after a card is dismissed and nothing else reveals it.
+ *
+ * Older builds of the native module have no `isAvailable`; treat its absence as
+ * "cannot tell", so nothing is claimed about why the card is missing.
+ */
+export const isAvailable = (): boolean => {
+  if (Platform.OS !== 'ios' || !native) return false;
+  if (typeof native.isAvailable !== 'function') return false;
+  return native.isAvailable();
+};
 
 /**
  * Whether a workout card is currently live. False after the user swipes it away,

--- a/frontend/modules/live-activity/ios/LiveActivityModule.swift
+++ b/frontend/modules/live-activity/ios/LiveActivityModule.swift
@@ -28,9 +28,21 @@ public class LiveActivityModule: Module {
       LiveActivityActionQueue.drain()
     }
 
+    /// Live Activities are usable *right now*: the OS can show them and the user
+    /// has not switched them off for Ischys.
     Function("isSupported") { () -> Bool in
       guard #available(iOS 16.1, *) else { return false }
       return ActivityAuthorizationInfo().areActivitiesEnabled
+    }
+
+    /// Whether the OS can show Live Activities at all, ignoring the per-app
+    /// switch. Paired with `isSupported`, this is what separates "this iPhone is
+    /// too old" from "you turned our card off" — iOS flips that switch by itself
+    /// once a card is dismissed, and without the distinction a workout just
+    /// silently had no Lock Screen card and no way to find out why.
+    Function("isAvailable") { () -> Bool in
+      guard #available(iOS 16.1, *) else { return false }
+      return true
     }
 
     /// Whether a workout Activity is currently live. Goes false when the user

--- a/frontend/src/components/workout/SetRow.tsx
+++ b/frontend/src/components/workout/SetRow.tsx
@@ -1,9 +1,6 @@
 /** A single logged-set row — grid: [34 | 1fr | 74 | 56 | 40], height 50. Pixel-critical. */
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import {
-  Animated,
-  Easing,
-  PanResponder,
   Platform,
   Pressable,
   StyleSheet,
@@ -22,7 +19,8 @@ import { color, font } from '../../theme/tokens';
  */
 export const KEYBOARD_ACCESSORY_ID = 'ischys-workout-keyboard';
 const accessoryId = Platform.OS === 'ios' ? KEYBOARD_ACCESSORY_ID : undefined;
-import { CheckIcon, TrashIcon } from '../icons';
+import { CheckIcon } from '../icons';
+import { SwipeToDelete } from './SwipeToDelete';
 import { prevLabel, typeMeta, type Exercise, type WorkoutSet } from './types';
 
 type Props = {
@@ -47,11 +45,6 @@ type Props = {
   carryWeight?: string;
   carryReps?: string;
 };
-
-// Matches the design's transform transition: cubic-bezier(0.22, 0.61, 0.36, 1), 220ms.
-const SWIPE_EASING = Easing.bezier(0.22, 0.61, 0.36, 1);
-const SWIPE_DURATION = 220;
-const OPEN_X = -72;
 
 export function SetRow({
   exercise,
@@ -80,85 +73,20 @@ export function SetRow({
     exercise.kind === 'bodyweight' ? 'BW' : carryWeight ?? set.prevWeight ?? '';
   const phReps = carryReps ?? set.prevReps ?? '';
 
-  const swipeEnabled = !!onDelete;
-
-  // Foreground translateX. Refs mirror the latest props so the PanResponder
-  // (created once) never reads stale values.
-  const tx = useRef(new Animated.Value(isOpen ? OPEN_X : 0)).current;
-  const isOpenRef = useRef(isOpen);
-  const onOpenChangeRef = useRef(onOpenChange);
-  onOpenChangeRef.current = onOpenChange;
-
-  const animateTo = (value: number) => {
-    Animated.timing(tx, {
-      toValue: value,
-      duration: SWIPE_DURATION,
-      easing: SWIPE_EASING,
-      useNativeDriver: true,
-    }).start();
-  };
-
-  // React to the panel being opened/closed from outside (e.g. another row opened).
-  useEffect(() => {
-    isOpenRef.current = isOpen;
-    animateTo(isOpen ? OPEN_X : 0);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen]);
-
-  const pan = useRef(
-    PanResponder.create({
-      // 8px / axis-dominance gate — the RN equivalent of touch-action: pan-y, so
-      // the parent ScrollView keeps vertical scrolling until the swipe is clearly horizontal.
-      onMoveShouldSetPanResponder: (_, g) =>
-        Math.abs(g.dx) > 8 && Math.abs(g.dx) > Math.abs(g.dy),
-      onPanResponderMove: (_, g) => {
-        const base = isOpenRef.current ? OPEN_X : 0;
-        let nx = base + g.dx;
-        if (nx > 0) nx = 0;
-        if (nx < -84) nx = -84;
-        tx.setValue(nx);
-      },
-      onPanResponderRelease: (_, g) => {
-        const base = isOpenRef.current ? OPEN_X : 0;
-        let nx = base + g.dx;
-        if (nx > 0) nx = 0;
-        if (nx < -84) nx = -84;
-        const open = nx < -40;
-        animateTo(open ? OPEN_X : 0);
-        onOpenChangeRef.current?.(open);
-      },
-      onPanResponderTerminate: () => {
-        animateTo(0);
-        onOpenChangeRef.current?.(false);
-      },
-    }),
-  ).current;
-
-  const panHandlers = swipeEnabled ? pan.panHandlers : {};
-
   return (
-    <View style={styles.container}>
-      {swipeEnabled && (
-        <Pressable
-          onPress={onDelete}
-          style={styles.deletePanel}
-          accessibilityRole="button"
-          accessibilityLabel={`Delete set ${badge}`}
-        >
-          <TrashIcon size={16} color="#fff" strokeWidth={2} />
-          <Text style={styles.deleteLabel}>Delete</Text>
-        </Pressable>
-      )}
-
-      <Animated.View
-        {...panHandlers}
-        style={[
-          styles.row,
-          // Opaque, and state-driven: the red delete panel sits behind this row.
-          { backgroundColor: set.done ? color.setRowDone : active ? color.setRowActive : color.surface1 },
-          { transform: [{ translateX: tx }] },
-        ]}
-      >
+    <SwipeToDelete
+      onDelete={onDelete}
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      accessibilityLabel={`Delete set ${badge}`}
+      radius={10}
+      rowStyle={[
+        styles.row,
+        // Opaque, and state-driven: the red delete panel sits behind this row.
+        { backgroundColor: set.done ? color.setRowDone : active ? color.setRowActive : color.surface1 },
+      ]}
+    >
+      <>
         {set.done && <View style={styles.doneBar} />}
         {active && <View style={[styles.doneBar, styles.activeBar]} />}
 
@@ -222,34 +150,12 @@ export function SetRow({
             />
           </Pressable>
         </View>
-      </Animated.View>
-    </View>
+      </>
+    </SwipeToDelete>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    position: 'relative',
-    borderRadius: 10,
-    overflow: 'hidden',
-  },
-  deletePanel: {
-    position: 'absolute',
-    top: 0,
-    right: 0,
-    bottom: 0,
-    width: 76,
-    backgroundColor: color.error,
-    flexDirection: 'column',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 3,
-  },
-  deleteLabel: {
-    color: '#fff',
-    fontFamily: font.titleSemi,
-    fontSize: 11,
-  },
   row: {
     position: 'relative',
     flexDirection: 'row',

--- a/frontend/src/components/workout/SwipeToDelete.tsx
+++ b/frontend/src/components/workout/SwipeToDelete.tsx
@@ -1,0 +1,155 @@
+/**
+ * Swipe-left-to-reveal-Delete wrapper for a list row.
+ *
+ * Extracted from `SetRow` so the routine editor's set rows get the identical
+ * affordance rather than a second, differently-behaved one. The parent owns
+ * "which row is open" (via `isOpen` + `onOpenChange`) so only one panel is ever
+ * revealed at a time.
+ */
+import type { ReactNode } from 'react';
+import { useEffect, useRef } from 'react';
+import {
+  Animated,
+  Easing,
+  PanResponder,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+
+import { TrashIcon } from '../icons';
+import { color, font } from '../../theme/tokens';
+
+// Matches the design's transform transition: cubic-bezier(0.22, 0.61, 0.36, 1), 220ms.
+const SWIPE_EASING = Easing.bezier(0.22, 0.61, 0.36, 1);
+const SWIPE_DURATION = 220;
+const OPEN_X = -72;
+const MAX_X = -84;
+
+type Props = {
+  /** Fired by the swipe-revealed Delete button. Omitted → swipe disabled, no panel. */
+  onDelete?: () => void;
+  /** This row's swipe panel is revealed. */
+  isOpen?: boolean;
+  /** Notify the parent when this row opens/closes so it can keep a single open row. */
+  onOpenChange?: (open: boolean) => void;
+  accessibilityLabel: string;
+  /** Corner radius of the clipping container — match the row's own radius. */
+  radius: number;
+  /** Style for the sliding foreground. Must be opaque: the panel sits behind it. */
+  rowStyle: StyleProp<ViewStyle>;
+  children: ReactNode;
+};
+
+export function SwipeToDelete({
+  onDelete,
+  isOpen = false,
+  onOpenChange,
+  accessibilityLabel,
+  radius,
+  rowStyle,
+  children,
+}: Props) {
+  const swipeEnabled = !!onDelete;
+
+  // Foreground translateX. Refs mirror the latest props so the PanResponder
+  // (created once) never reads stale values.
+  const tx = useRef(new Animated.Value(isOpen ? OPEN_X : 0)).current;
+  const isOpenRef = useRef(isOpen);
+  const onOpenChangeRef = useRef(onOpenChange);
+  onOpenChangeRef.current = onOpenChange;
+
+  const animateTo = (value: number) => {
+    Animated.timing(tx, {
+      toValue: value,
+      duration: SWIPE_DURATION,
+      easing: SWIPE_EASING,
+      useNativeDriver: true,
+    }).start();
+  };
+
+  // React to the panel being opened/closed from outside (e.g. another row opened).
+  useEffect(() => {
+    isOpenRef.current = isOpen;
+    animateTo(isOpen ? OPEN_X : 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  const pan = useRef(
+    PanResponder.create({
+      // 8px / axis-dominance gate — the RN equivalent of touch-action: pan-y, so
+      // the parent ScrollView keeps vertical scrolling until the swipe is clearly horizontal.
+      onMoveShouldSetPanResponder: (_, g) =>
+        Math.abs(g.dx) > 8 && Math.abs(g.dx) > Math.abs(g.dy),
+      onPanResponderMove: (_, g) => {
+        const base = isOpenRef.current ? OPEN_X : 0;
+        let nx = base + g.dx;
+        if (nx > 0) nx = 0;
+        if (nx < MAX_X) nx = MAX_X;
+        tx.setValue(nx);
+      },
+      onPanResponderRelease: (_, g) => {
+        const base = isOpenRef.current ? OPEN_X : 0;
+        let nx = base + g.dx;
+        if (nx > 0) nx = 0;
+        if (nx < MAX_X) nx = MAX_X;
+        const open = nx < -40;
+        animateTo(open ? OPEN_X : 0);
+        onOpenChangeRef.current?.(open);
+      },
+      onPanResponderTerminate: () => {
+        animateTo(0);
+        onOpenChangeRef.current?.(false);
+      },
+    }),
+  ).current;
+
+  const panHandlers = swipeEnabled ? pan.panHandlers : {};
+
+  return (
+    <View style={[styles.container, { borderRadius: radius }]}>
+      {swipeEnabled && (
+        <Pressable
+          onPress={onDelete}
+          style={styles.deletePanel}
+          accessibilityRole="button"
+          accessibilityLabel={accessibilityLabel}
+        >
+          <TrashIcon size={16} color="#fff" strokeWidth={2} />
+          <Text style={styles.deleteLabel}>Delete</Text>
+        </Pressable>
+      )}
+
+      <Animated.View {...panHandlers} style={[rowStyle, { transform: [{ translateX: tx }] }]}>
+        {children}
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'relative',
+    overflow: 'hidden',
+  },
+  deletePanel: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    width: 76,
+    backgroundColor: color.error,
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 3,
+  },
+  deleteLabel: {
+    color: '#fff',
+    fontFamily: font.titleSemi,
+    fontSize: 11,
+  },
+});

--- a/frontend/src/lib/healthSync.ts
+++ b/frontend/src/lib/healthSync.ts
@@ -142,9 +142,21 @@ export async function syncFinishedWorkout(
       // times out and the phone writes the (energy-less) workout itself rather
       // than lose it. With no Watch, the phone writes straight away.
       const watchSaved = await watchSavePromise;
-      const saved = watchSaved
-        ? true
-        : await Health.saveWorkout(startedAtMs, endedAtMs, metrics.energyKcal ?? 0);
+      // A timeout is not proof the Watch failed to save — only that it failed to
+      // say so in time, which is common: `workoutSaved` travels over
+      // WatchConnectivity, and with the phone app not frontmost (the usual case
+      // when the workout was ended FROM the Watch) it falls back to
+      // `transferUserInfo` and is queued until the phone next runs. The
+      // HKWorkout is already in Health by then and writing another puts the
+      // session in Fitness twice. HealthKit is the authority, so ask it before
+      // writing — and it also covers a phone-side sync that ran twice.
+      const alreadyInHealth = watchSaved
+        ? false
+        : await Health.hasWorkout(startedAtMs, endedAtMs);
+      const saved =
+        watchSaved || alreadyInHealth
+          ? true
+          : await Health.saveWorkout(startedAtMs, endedAtMs, metrics.energyKcal ?? 0);
       if (saved) {
         await SecureStore.setItemAsync(HEALTH_KEYS.lastSync, new Date().toISOString());
         const prev = Number(await SecureStore.getItemAsync(HEALTH_KEYS.written)) || 0;

--- a/frontend/src/lib/liveActivityBridge.ts
+++ b/frontend/src/lib/liveActivityBridge.ts
@@ -22,7 +22,12 @@ import { buildLiveActivityState } from './liveActivityState';
 export type RestAction = { type: 'skip' } | { type: 'adjust'; seconds: number };
 
 type RestListener = (action: RestAction) => void;
-type ChangeListener = (restSeconds: number) => void;
+/**
+ * `exerciseId` is the workout-exercise the completed set belonged to — i.e. the
+ * one the rest that follows is *for*. The screen needs it to know whether a
+ * later change to an exercise's rest duration should retime the running rest.
+ */
+type ChangeListener = (rest: { seconds: number; exerciseId: string }) => void;
 
 const restListeners = new Set<RestListener>();
 const changeListeners = new Set<ChangeListener>();
@@ -64,7 +69,10 @@ const forSnapshot = (w: WorkoutOut) =>
  * logs exactly what the app would have logged. Returns the rest to start, or
  * null if the set was already done (a queued tap can outlive a resume).
  */
-async function completeSet(w: WorkoutOut, setId: string): Promise<number | null> {
+async function completeSet(
+  w: WorkoutOut,
+  setId: string,
+): Promise<{ seconds: number; exerciseId: string } | null> {
   const we = w.exercises.find((e) => e.sets.some((s) => s.id === setId));
   const index = we?.sets.findIndex((s) => s.id === setId) ?? -1;
   if (!we || index === -1) return null;
@@ -82,7 +90,7 @@ async function completeSet(w: WorkoutOut, setId: string): Promise<number | null>
   if (patch.weight !== undefined) set.weight = patch.weight;
   if (patch.reps !== undefined) set.reps = patch.reps;
 
-  return we.rest_seconds;
+  return { seconds: we.rest_seconds, exerciseId: we.id };
 }
 
 /** Re-push the card from server truth, refilling `next`. */
@@ -132,16 +140,16 @@ export async function applyPendingCardActions(): Promise<void> {
     if (!active) return;
     const workout = await getWorkout(active.id);
 
-    let rest: number | null = null;
+    let rest: { seconds: number; exerciseId: string } | null = null;
     for (const done of completions) {
       if (done.action !== 'completeSet') continue;
-      const seconds = await completeSet(workout, done.setId);
-      if (seconds != null) rest = seconds;
+      const applied = await completeSet(workout, done.setId);
+      if (applied != null) rest = applied;
     }
 
     if (rest == null) return; // every tap was stale
     changeListeners.forEach((l) => l(rest));
-    await pushCard(workout, rest);
+    await pushCard(workout, rest.seconds);
   } catch {
     // The queue is already drained. Losing a tap beats applying it twice, and
     // the screen refetches from the server whenever it regains focus.

--- a/frontend/src/lib/liveActivityHint.ts
+++ b/frontend/src/lib/liveActivityHint.ts
@@ -1,0 +1,38 @@
+/**
+ * Remembers that we have already told the user their Live Activities are off.
+ *
+ * iOS turns the per-app switch off by itself once a card is dismissed, so a
+ * workout can quietly have no Lock Screen card forever. Worth saying once — and
+ * only once, because a nag at the start of every workout is worse than the bug.
+ *
+ * The flag is cleared whenever a card does start, so if the switch is ever
+ * turned off again the next workout gets one fresh reminder.
+ */
+import * as SecureStore from 'expo-secure-store';
+
+const KEY = 'ischys.liveActivityDisabledHintShown';
+
+export function liveActivityHintShown(): boolean {
+  try {
+    return SecureStore.getItem(KEY) === '1';
+  } catch {
+    // Storage unavailable — treat as shown rather than risk repeating it.
+    return true;
+  }
+}
+
+export function rememberLiveActivityHint(): void {
+  try {
+    SecureStore.setItem(KEY, '1');
+  } catch {
+    // Losing the flag only costs one repeated hint.
+  }
+}
+
+export function forgetLiveActivityHint(): void {
+  try {
+    SecureStore.deleteItemAsync(KEY).catch(() => {});
+  } catch {
+    // as above
+  }
+}

--- a/frontend/src/lib/liveActivityState.test.ts
+++ b/frontend/src/lib/liveActivityState.test.ts
@@ -111,3 +111,35 @@ test('the workout’s last set has no next', () => {
   const s = buildLiveActivityState(legPress(set('a', '154', '12')), false, resolve);
   assert.equal(s?.next, undefined);
 });
+
+test('the look-ahead crosses the boundary on an exercise’s LAST set', () => {
+  // #19: on the final set of Squat, `next` must be Bench set 1 — never another
+  // set of Squat. This is what the card's ✓ redraws itself into.
+  const s = buildLiveActivityState(
+    [
+      { name: 'Squat', rest: 180, sets: [set('a', '100', '5', true), set('b', '100', '5')] },
+      { name: 'Bench', rest: 90, sets: [set('c', '80', '8'), set('d', '80', '8')] },
+    ],
+    false,
+    resolve,
+  );
+  assert.equal(s?.setId, 'b');
+  assert.equal(s?.next?.exerciseName, 'Bench');
+  assert.equal(s?.next?.setId, 'c');
+  assert.equal(s?.next?.subtitle, 'Next: set 1 of 2 (80 kg × 8 reps)');
+});
+
+test('resting after an exercise’s last set describes the next exercise', () => {
+  // Same moment, one tick later: the completed set is now `done`, so the card
+  // is already showing Bench rather than a stale Squat.
+  const s = buildLiveActivityState(
+    [
+      { name: 'Squat', rest: 180, sets: [set('a', '100', '5', true), set('b', '100', '5', true)] },
+      { name: 'Bench', rest: 90, sets: [set('c', '80', '8'), set('d', '80', '8')] },
+    ],
+    true,
+    resolve,
+  );
+  assert.equal(s?.exerciseName, 'Bench');
+  assert.equal(s?.subtitle, 'Next: set 1 of 2 (80 kg × 8 reps)');
+});

--- a/frontend/src/lib/liveActivityState.ts
+++ b/frontend/src/lib/liveActivityState.ts
@@ -10,10 +10,12 @@
  * wake up and push. JS still owns the write; this is only so the card responds
  * to a tap on a locked phone.
  *
- * Pure — no imports, so `node --test` can run it. The carry-forward rules are
- * injected as `resolve` rather than imported, keeping this file self-contained
- * (see setCarry.ts, which is tested separately). See liveActivityState.test.ts.
+ * Pure — the only import is the shared look-ahead, so `node --test` can run it.
+ * The carry-forward rules are injected as `resolve` rather than imported,
+ * keeping this file self-contained (see setCarry.ts, which is tested
+ * separately). See liveActivityState.test.ts.
  */
+import { locateNextSet } from './nextSet.ts';
 
 export type LiveActivityMode = 'logging' | 'rest';
 
@@ -61,30 +63,19 @@ const weightLabelFor = (weight: string): string =>
 const repsLabelFor = (reps: string): string =>
   reps.trim() === '' ? '—' : `${reps.trim()} reps`;
 
-type Located = { ex: ExerciseLike; index: number };
-
-/** First set that is neither done nor `treatAsDone`, scanning exercises in order. */
-function locate(
-  exercises: readonly ExerciseLike[],
-  treatAsDone?: string,
-): Located | null {
-  for (const ex of exercises) {
-    const index = ex.sets.findIndex((s) => !s.done && s.id !== treatAsDone);
-    if (index !== -1) return { ex, index };
-  }
-  return null;
-}
+type Located = { exercise: ExerciseLike; setIndex: number };
 
 function describe(at: Located, resolve: Resolve): NextSet {
-  const filled = resolve(at.ex.sets, at.index);
+  const { exercise, setIndex } = at;
+  const filled = resolve(exercise.sets, setIndex);
   const weightLabel = weightLabelFor(filled.weight);
   const repsLabel = repsLabelFor(filled.reps);
   return {
-    exerciseName: at.ex.name,
-    subtitle: `Next: set ${at.index + 1} of ${at.ex.sets.length} (${weightLabel} ${TIMES} ${repsLabel})`,
+    exerciseName: exercise.name,
+    subtitle: `Next: set ${setIndex + 1} of ${exercise.sets.length} (${weightLabel} ${TIMES} ${repsLabel})`,
     weightLabel,
     repsLabel,
-    setId: at.ex.sets[at.index].id,
+    setId: exercise.sets[setIndex].id,
   };
 }
 
@@ -97,17 +88,17 @@ export function buildLiveActivityState(
   resting: boolean,
   resolve: Resolve,
 ): LiveActivitySnapshot | null {
-  const current = locate(exercises);
+  const current = locateNextSet(exercises);
   if (!current) return null;
 
-  const { ex, index } = current;
+  const { exercise: ex, setIndex: index } = current;
   const set = ex.sets[index];
   const filled = resolve(ex.sets, index);
   const weightLabel = weightLabelFor(filled.weight);
   const repsLabel = repsLabelFor(filled.reps);
   const position = `set ${index + 1} of ${ex.sets.length}`;
 
-  const after = locate(exercises, set.id);
+  const after = locateNextSet(exercises, set.id);
 
   return {
     exerciseName: ex.name,

--- a/frontend/src/lib/nextSet.test.ts
+++ b/frontend/src/lib/nextSet.test.ts
@@ -1,0 +1,85 @@
+/** Run with: npm test */
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { locateNextSet } from './nextSet.ts';
+
+const set = (id: string, done = false) => ({ id, done });
+const ex = (name: string, ...sets: { id: string; done: boolean }[]) => ({ name, sets });
+
+test('finds the first unfinished set of the first exercise', () => {
+  const at = locateNextSet([ex('Squat', set('a', true), set('b'), set('c'))]);
+  assert.equal(at?.exercise.name, 'Squat');
+  assert.equal(at?.exerciseIndex, 0);
+  assert.equal(at?.setIndex, 1);
+});
+
+test('skips an exercise whose sets are all done', () => {
+  const at = locateNextSet([
+    ex('Squat', set('a', true), set('b', true)),
+    ex('Bench', set('c')),
+  ]);
+  assert.equal(at?.exercise.name, 'Bench');
+  assert.equal(at?.exerciseIndex, 1);
+  assert.equal(at?.setIndex, 0);
+});
+
+test('skips an exercise that has no sets at all', () => {
+  const at = locateNextSet([ex('Empty'), ex('Bench', set('c'))]);
+  assert.equal(at?.exercise.name, 'Bench');
+  assert.equal(at?.exerciseIndex, 1);
+});
+
+test('null once every set is done', () => {
+  assert.equal(locateNextSet([ex('Squat', set('a', true))]), null);
+});
+
+test('null for an empty workout', () => {
+  assert.equal(locateNextSet([]), null);
+});
+
+// --- treatAsDone: answering at the instant a set is completed ---
+
+test('treatAsDone advances within the same exercise', () => {
+  const at = locateNextSet([ex('Squat', set('a'), set('b'))], 'a');
+  assert.equal(at?.exercise.name, 'Squat');
+  assert.equal(at?.setIndex, 1);
+});
+
+test('treatAsDone crosses into the next exercise after an exercise’s LAST set', () => {
+  // The #19/#20 case: completing the last set of A must point at B, set 1 —
+  // not back at a set of A.
+  const at = locateNextSet(
+    [ex('Squat', set('a', true), set('b')), ex('Bench', set('c'), set('d'))],
+    'b',
+  );
+  assert.equal(at?.exercise.name, 'Bench');
+  assert.equal(at?.exerciseIndex, 1);
+  assert.equal(at?.setIndex, 0);
+});
+
+test('treatAsDone skips over an exercise that is now fully accounted for', () => {
+  const at = locateNextSet(
+    [ex('Squat', set('a', true), set('b')), ex('Empty'), ex('Bench', set('c'))],
+    'b',
+  );
+  assert.equal(at?.exercise.name, 'Bench');
+  assert.equal(at?.exerciseIndex, 2);
+});
+
+test('treatAsDone on the workout’s very last set leaves nothing next', () => {
+  const at = locateNextSet([ex('Squat', set('a', true), set('b'))], 'b');
+  assert.equal(at, null);
+});
+
+test('a set left unfinished ABOVE the completed one is still what comes next', () => {
+  // Skipping a set does not remove it from the workout; it is the first thing
+  // outstanding, so it is what the user is sent back to.
+  const at = locateNextSet([ex('Squat', set('a'), set('b'))], 'b');
+  assert.equal(at?.setIndex, 0);
+});
+
+test('an unknown treatAsDone id changes nothing', () => {
+  const at = locateNextSet([ex('Squat', set('a'), set('b'))], 'nope');
+  assert.equal(at?.setIndex, 0);
+});

--- a/frontend/src/lib/nextSet.ts
+++ b/frontend/src/lib/nextSet.ts
@@ -1,0 +1,43 @@
+/**
+ * "Which set comes next?" — the one look-ahead the phone, the Lock Screen card,
+ * the Watch and the end-of-rest notification all have to agree on.
+ *
+ * It scans the whole workout, not one exercise: the set after an exercise's last
+ * one is the *next exercise's* first set. Each surface used to answer this its
+ * own way and they disagreed — the Watch clamped to the current exercise's last
+ * set (#20) and the rest notification named the exercise you had just finished
+ * (#19).
+ *
+ * `treatAsDone` exists because the answer is usually needed at the instant a set
+ * is completed, before `setExercises` has re-rendered: pass the id of the set
+ * being completed and it is skipped as if already done.
+ *
+ * Pure — no imports, so `node --test` can run it. See nextSet.test.ts.
+ */
+
+type SetLike = { id: string; done: boolean };
+type ExerciseLike = { sets: readonly SetLike[] };
+
+export type LocatedSet<E> = {
+  exercise: E;
+  /** Index into `exercises`. */
+  exerciseIndex: number;
+  /** Index into `exercise.sets`. */
+  setIndex: number;
+};
+
+/**
+ * The first set that is neither `done` nor `treatAsDone`, scanning exercises in
+ * order. `null` when the workout has nothing left to do.
+ */
+export function locateNextSet<E extends ExerciseLike>(
+  exercises: readonly E[],
+  treatAsDone?: string,
+): LocatedSet<E> | null {
+  for (let exerciseIndex = 0; exerciseIndex < exercises.length; exerciseIndex++) {
+    const exercise = exercises[exerciseIndex];
+    const setIndex = exercise.sets.findIndex((s) => !s.done && s.id !== treatAsDone);
+    if (setIndex !== -1) return { exercise, exerciseIndex, setIndex };
+  }
+  return null;
+}

--- a/frontend/src/lib/watchState.test.ts
+++ b/frontend/src/lib/watchState.test.ts
@@ -77,16 +77,46 @@ test('volume and set counts cover done, non-warmup sets only', () => {
   assert.equal(s?.setsTotal, 4);
 });
 
-test('the next-set label never runs past the last set', () => {
-  const s = buildWatchState(legPress(set('a', '1', '1'), set('b', '1', '1')), 'R', rest, resolve);
-  assert.equal(s?.nextSetLabel, 'Next: Set 2');
-  const last = buildWatchState(
-    legPress(set('a', '1', '1', true), set('b', '1', '1')),
+/**
+ * The Rest screen shows only this line, so it names the set the rest is for —
+ * the located set, which during rest is the one you are about to do.
+ */
+test('the next-set label describes the set the rest is for', () => {
+  const s = buildWatchState(
+    legPress(set('a', '1', '1', true), set('b', '1', '1'), set('c', '1', '1')),
     'R',
-    rest,
+    { resting: true, remaining: 45, total: 90 },
     resolve,
   );
-  assert.equal(last?.nextSetLabel, 'Next: Set 2');
+  assert.equal(s?.nextSetLabel, 'Next: Set 2 of 3');
+});
+
+test('the next-set label advances to the next exercise after an exercise’s last set', () => {
+  // #20: this used to clamp to the current exercise's last set and read
+  // "Next: Set 2" — a set of the exercise the user had just finished.
+  const s = buildWatchState(
+    [
+      {
+        id: 'e1',
+        name: 'Squat',
+        equipment: 'Barbell',
+        rest: 180,
+        sets: [set('a', '100', '5', true), set('b', '100', '5', true)],
+      },
+      {
+        id: 'e2',
+        name: 'Bench',
+        equipment: 'Barbell',
+        rest: 120,
+        sets: [set('c', '80', '5'), set('d', '80', '5'), set('e', '80', '5')],
+      },
+    ],
+    'R',
+    { resting: true, remaining: 45, total: 90 },
+    resolve,
+  );
+  assert.equal(s?.exerciseName, 'Bench');
+  assert.equal(s?.nextSetLabel, 'Next: Set 1 of 3');
 });
 
 test('rest state passes through', () => {

--- a/frontend/src/lib/watchState.test.ts
+++ b/frontend/src/lib/watchState.test.ts
@@ -119,6 +119,16 @@ test('the next-set label advances to the next exercise after an exercise’s las
   assert.equal(s?.nextSetLabel, 'Next: Set 1 of 3');
 });
 
+test('the workout start is pushed, so the Watch counts elapsed from it', () => {
+  const s = buildWatchState(legPress(set('a', '1', '1')), 'R', rest, resolve, 1_700_000_000_000);
+  assert.equal(s?.startedAt, 1_700_000_000_000);
+});
+
+test('an unknown workout start pushes 0, not a 1970 origin', () => {
+  const s = buildWatchState(legPress(set('a', '1', '1')), 'R', rest, resolve);
+  assert.equal(s?.startedAt, 0);
+});
+
 test('rest state passes through', () => {
   const s = buildWatchState(
     legPress(set('a', '1', '1', true), set('b', '1', '1')),

--- a/frontend/src/lib/watchState.ts
+++ b/frontend/src/lib/watchState.ts
@@ -5,9 +5,11 @@
  * pushed from the iPhone"). This builds the snapshot the Watch's `PhoneState`
  * decodes — the current set, the set-progress dots, and the session totals.
  *
- * Pure — no imports, so `node --test` can run it. The carry-forward rule is
- * injected as `resolve` (see setCarry.ts), keeping this self-contained.
+ * Pure — the only import is the shared look-ahead, so `node --test` can run it.
+ * The carry-forward rule is injected as `resolve` (see setCarry.ts), keeping
+ * this self-contained.
  */
+import { locateNextSet } from './nextSet.ts';
 
 export type WatchSetDot = 'done' | 'active' | 'pending';
 
@@ -51,16 +53,6 @@ export type WatchState = {
   currentSetId: string;
 };
 
-type Located = { ex: ExerciseLike & { id: string }; index: number };
-
-function locate(exercises: readonly (ExerciseLike & { id: string })[]): Located | null {
-  for (const ex of exercises) {
-    const index = ex.sets.findIndex((s) => !s.done);
-    if (index !== -1) return { ex, index };
-  }
-  return null;
-}
-
 /**
  * Parse a typed weight. `decimal-pad` inserts the locale decimal separator, so a
  * comma-locale keyboard yields "24,8" — `parseFloat` would stop at the comma and
@@ -95,10 +87,10 @@ export function buildWatchState(
   rest: { resting: boolean; remaining: number; total: number },
   resolve: Resolve,
 ): WatchState | null {
-  const current = locate(exercises);
+  const current = locateNextSet(exercises);
   if (!current) return null;
 
-  const { ex, index } = current;
+  const { exercise: ex, setIndex: index } = current;
   const set = ex.sets[index];
   const filled = resolve(ex.sets, index);
 
@@ -123,7 +115,14 @@ export function buildWatchState(
     resting: rest.resting,
     restRemaining: rest.remaining,
     restTotal: rest.total,
-    nextSetLabel: `Next: Set ${Math.min(index + 2, ex.sets.length)}`,
+    // The Watch's Rest screen shows only this line, so it must describe the set
+    // the rest is *for* — which is the located set: during rest the set just
+    // completed is already `done`, so the look-ahead has moved on (crossing into
+    // the next exercise when the last set of one is finished). The old
+    // `Math.min(index + 2, ex.sets.length)` looked one set too far and then
+    // clamped inside the current exercise, so the final set of an exercise
+    // showed its own number back as "next".
+    nextSetLabel: `Next: Set ${index + 1} of ${ex.sets.length}`,
     volumeKg: t.volumeKg,
     setsDone: t.setsDone,
     setsTotal: t.setsTotal,

--- a/frontend/src/lib/watchState.ts
+++ b/frontend/src/lib/watchState.ts
@@ -31,6 +31,14 @@ type Resolve = (
 
 export type WatchState = {
   screen: 'session';
+  /**
+   * Epoch ms the *workout* began — the Watch's elapsed clock counts from this.
+   * Its own `HKWorkoutSession` starts whenever the Watch app got going, which
+   * can be seconds or minutes later, and counting from that made the two clocks
+   * disagree (#32). 0 when the phone doesn't know it yet; the Watch then keeps
+   * its session start rather than jumping to 1970.
+   */
+  startedAt: number;
   routineName: string;
   exerciseName: string;
   equipment: string;
@@ -86,6 +94,8 @@ export function buildWatchState(
   routineName: string,
   rest: { resting: boolean; remaining: number; total: number },
   resolve: Resolve,
+  /** Epoch ms the workout began; omit (or null) before it is known. */
+  startedAt: number | null = null,
 ): WatchState | null {
   const current = locateNextSet(exercises);
   if (!current) return null;
@@ -102,6 +112,7 @@ export function buildWatchState(
 
   return {
     screen: 'session',
+    startedAt: startedAt ?? 0,
     routineName,
     exerciseName: ex.name,
     equipment: ex.equipment,

--- a/frontend/targets/ischys-watch/ActiveSetView.swift
+++ b/frontend/targets/ischys-watch/ActiveSetView.swift
@@ -14,6 +14,9 @@ struct ActiveSetView: View {
   @State private var editing: Field = .weight
   /// Crown-driven value for the selected field, written back as a string.
   @State private var crownValue: Double = 0
+  /// Set while a `seedCrown` write is in flight, so the `crownValue` change it
+  /// causes is not mistaken for the user turning the Crown.
+  @State private var seeding = false
   @FocusState private var crownFocused: Bool
 
   private var content: some View {
@@ -38,7 +41,10 @@ struct ActiveSetView: View {
         sensitivity: .medium, isContinuous: false, isHapticFeedbackEnabled: true
       )
       .onChange(of: crownValue) { _, v in applyCrown(v) }
-      .onChange(of: model.setNum) { _, _ in seedCrown() }
+      // Re-seed whenever the phone replaced the values — a new set, or an edit
+      // to the one we are on. Keyed on the model's seed counter rather than
+      // `setNum`, which missed the second case entirely (#30).
+      .onChange(of: model.valueSeed) { _, _ in seedCrown() }
       .onAppear {
         seedCrown()
         crownFocused = true
@@ -51,10 +57,25 @@ struct ActiveSetView: View {
   }
 
   private func seedCrown() {
-    crownValue = Double(editing == .weight ? model.weight : model.reps) ?? 0
+    // A comma-locale keyboard on the phone yields "24,8"; `Double` would reject
+    // it and drop the Crown to 0, so normalise the separator first.
+    let text = editing == .weight ? model.weight : model.reps
+    let next = Double(text.replacingOccurrences(of: ",", with: ".")) ?? 0
+    // An unchanged value fires no `onChange`, so `seeding` must not be armed for
+    // a write that will never land — it would swallow the user's next real turn.
+    guard next != crownValue else { return }
+    seeding = true
+    crownValue = next
   }
 
   private func applyCrown(_ v: Double) {
+    // Our own seed, not the user's wrist: leave the phone's value exactly as
+    // pushed rather than rewriting it through the 0.5 rounding below.
+    if seeding {
+      seeding = false
+      return
+    }
+    model.noteCrownEdit()
     if editing == .weight {
       // Keep the 0.5 step: whole numbers show plain, halves show one decimal.
       let w = (v * 2).rounded() / 2

--- a/frontend/targets/ischys-watch/PhoneLink.swift
+++ b/frontend/targets/ischys-watch/PhoneLink.swift
@@ -9,6 +9,9 @@ import WatchConnectivity
 struct PhoneState {
   var screen: WatchScreen = .start
   var routines: [RoutineItem] = []
+  /// When the *workout* began, not when this Watch's session did. nil when the
+  /// phone hasn't said (it pushes 0), so the Watch keeps its own origin.
+  var startedAt: Date?
   var routineName = ""
   var exerciseName = ""
   var equipment = ""
@@ -43,6 +46,11 @@ struct PhoneState {
           exerciseCount: $0["exerciseCount"] as? Int ?? 0
         )
       }
+    }
+    // Epoch milliseconds. A Double covers it exactly; `as? Int` would fail on a
+    // JS number that arrives bridged as NSNumber(double).
+    if let ms = (d["startedAt"] as? NSNumber)?.doubleValue, ms > 0 {
+      startedAt = Date(timeIntervalSince1970: ms / 1000)
     }
     routineName = d["routineName"] as? String ?? ""
     exerciseName = d["exerciseName"] as? String ?? ""

--- a/frontend/targets/ischys-watch/WorkoutModel.swift
+++ b/frontend/targets/ischys-watch/WorkoutModel.swift
@@ -87,27 +87,39 @@ final class WorkoutModel: ObservableObject {
 
   private var restTimer: AnyCancellable?
   private var elapsedTimer: AnyCancellable?
-  private var sessionStart: Date?
 
-  /// Drives the 1 Hz rest countdown and the elapsed clock while a session runs.
+  /// Where the elapsed clock counts from.
+  ///
+  /// Our `HKWorkoutSession` starts whenever the Watch app got going, which is
+  /// not when the workout started — the phone can launch us seconds later, or
+  /// the user can open the Watch app mid-session. Counting from the session made
+  /// the Watch's elapsed disagree with the phone's, so the phone's `startedAt`
+  /// wins as soon as it arrives and the session start is only the fallback until
+  /// then (see `apply`).
+  private var elapsedOrigin: Date?
+
+  /// Drives the elapsed clock while a session runs.
   func startTicking(sessionStart: Date) {
-    self.sessionStart = sessionStart
+    // Only a seed: a `startedAt` already pushed by the phone is the better
+    // origin and must not be thrown away by the session starting afterwards.
+    if elapsedOrigin == nil { elapsedOrigin = sessionStart }
     elapsedTimer = Timer.publish(every: 1, on: .main, in: .common)
       .autoconnect()
       .sink { [weak self] _ in self?.tick() }
+    tick() // Don't show 0 for the first second of a workout already underway.
   }
 
   func stopTicking() {
     elapsedTimer?.cancel()
     elapsedTimer = nil
-    sessionStart = nil
+    elapsedOrigin = nil
   }
 
   private func tick() {
     // Only elapsed ticks locally. Rest is NOT decremented here: the phone pushes
     // restRemaining every second, and ticking it too would run it down twice as
     // fast. The elapsed clock is local because the phone doesn't push it.
-    if let start = sessionStart {
+    if let start = elapsedOrigin {
       elapsedSec = max(0, Int(Date().timeIntervalSince(start)))
     }
   }
@@ -118,6 +130,14 @@ final class WorkoutModel: ObservableObject {
   /// owns are overwritten; locally-edited weight/reps are replaced only when the
   /// current set changed (a new set means new seed values).
   func apply(_ s: PhoneState) {
+    // The workout's own start beats our session's, and updates the clock at once
+    // rather than at the next tick — otherwise the Watch shows a visibly wrong
+    // elapsed for up to a second every time it joins a session already running.
+    if let started = s.startedAt, started != elapsedOrigin {
+      elapsedOrigin = started
+      tick()
+    }
+
     screen = s.screen
     routines = s.routines
     routineName = s.routineName

--- a/frontend/targets/ischys-watch/WorkoutModel.swift
+++ b/frontend/targets/ischys-watch/WorkoutModel.swift
@@ -64,6 +64,12 @@ final class WorkoutModel: ObservableObject {
   @Published var prevReps = ""
   @Published var setDots: [SetDot] = []
 
+  /// Bumped whenever `weight`/`reps` were replaced by the phone. The Crown keeps
+  /// its own Double, so the Active Set view has to be told to re-seed it —
+  /// without that, the display would show the new number while the next notch
+  /// wrote the old one straight back.
+  @Published var valueSeed = 0
+
   // S3 — Rest. `restRemaining` ticks locally; the phone owns start/total.
   @Published var resting = false
   @Published var restRemaining = 0
@@ -97,6 +103,23 @@ final class WorkoutModel: ObservableObject {
   /// wins as soon as it arrives and the session start is only the fallback until
   /// then (see `apply`).
   private var elapsedOrigin: Date?
+
+  // MARK: Crown arbitration
+
+  /// When the user last turned the Digital Crown. The phone is the source of
+  /// truth for weight/reps, but a value yanked out from under a wrist that is
+  /// mid-adjustment is worse than a value a couple of seconds stale — so a
+  /// pushed edit waits for the Crown to go quiet.
+  private var lastCrownEdit: Date?
+  private let crownGrace: TimeInterval = 3
+
+  /// Called by the Active Set view on a real user turn (not on a re-seed).
+  func noteCrownEdit() { lastCrownEdit = Date() }
+
+  private var crownIsBusy: Bool {
+    guard let last = lastCrownEdit else { return false }
+    return Date().timeIntervalSince(last) < crownGrace
+  }
 
   /// Drives the elapsed clock while a session runs.
   func startTicking(sessionStart: Date) {
@@ -153,11 +176,20 @@ final class WorkoutModel: ObservableObject {
     setsTotal = s.setsTotal
     summary = s.summary
 
-    // A changed exercise/set reseeds the Crown-editable values; an unchanged set
-    // keeps the user's local Crown edit.
-    if s.exerciseName != exerciseName || s.setNum != setNum {
+    // A changed exercise/set always reseeds the Crown-editable values — a new set
+    // means new seed values.
+    let setChanged = s.exerciseName != exerciseName || s.setNum != setNum
+    // So does an edit the phone made to the set we are already on (#30). This
+    // used to be ignored entirely, so typing a weight on the phone before
+    // ticking the set off left the Watch showing the old number. The one thing
+    // that outranks the phone is a wrist mid-turn; that edit lands once the
+    // Crown goes quiet, or when the set changes.
+    let pushedEdit = !setChanged && !crownIsBusy && (s.weight != weight || s.reps != reps)
+    if setChanged || pushedEdit {
       weight = s.weight
       reps = s.reps
+      if setChanged { lastCrownEdit = nil }
+      valueSeed &+= 1
     }
     exerciseName = s.exerciseName
     setNum = s.setNum


### PR DESCRIPTION
Closes #15, #16, #17, #18, #19, #20, #21, #29, #30, #32 — the whole **Release 1 — Cleanup** milestone.

One commit per issue (#19/#20 share a commit, since they are one extracted helper). Nothing outside the milestone was touched: no `needs-design` items (#22–#25, #31), no Release 2 features (#26–#28).

**Verification:** `npx tsc --noEmit` clean, `npm test` **182/182 pass** (was 166 — 16 new tests). Both re-run on the final tree.

⚠️ **This needs a native rebuild, not a JS reload.** #29, #21, #30 and #32 all change Swift.

---

## #15 — Exercise picker dropped selections from earlier searches

**Wrong:** `handleAdd` rebuilt the returned list by looking each selected id up in `exercises` — the *currently filtered* result set. Selecting "bench", then searching "squat", left the bench row out of the array, so its id resolved to nothing and the pick was silently dropped.

**Changed:** `selected` is now a `Map<id, ExerciseOut>` holding the objects themselves, filled by `toggle`. The returned list no longer depends on the current filter. Insertion order is the add order.

**Verified:** tsc + tests. Needs a manual pass: select across three different searches, confirm all three land.

## #16 — Save silently disabled on a nameless routine

**Wrong:** Save rendered `disabled` with `opacity 0.5` and `pointerEvents: 'none'` whenever the name was blank. Tapping it did nothing and said nothing.

**Changed:** Save stays tappable; the tap does the explaining. It sets an inline error under the name field (*"Give your routine a name to save it."*), tints the placeholder red, and focuses the input. Clears as soon as a non-blank name is typed. The dimmed button is kept as the at-a-glance hint.

**Design note:** used the existing inline red-line treatment (`errorLine` in the exercise library and New Exercise screens) rather than inventing anything. No new pattern introduced.

## #17 — No way to remove a set in the routine editor

**Wrong:** `addSet` existed, nothing removed one.

**Changed:** mirrored the active-workout screen's affordance instead of inventing a second one — swipe the row left to reveal Delete, parent keeps at most one row open. To make them genuinely identical, the swipe mechanics moved out of `SetRow` into a shared `SwipeToDelete` wrapper (pan gate, 220ms easing, −72px open offset, 76px panel — all unchanged) that both screens use.

Removing the last set of an exercise is allowed, matching `deleteSet` on the workout screen; `+ Add Set` is right there to undo it.

**Needs a look:** `SetRow` should render pixel-identically (only where the animation lives moved), but the workout screen is pixel-critical — worth an eyeball on both screens.

## #18 — Rest-duration change didn't affect the running rest

**Wrong:** `setRest` only wrote the exercise's `rest` field. Nothing recomputed `restTotal`/`restEndsAt`, so a duration changed mid-countdown had no visible effect until the next set.

**Changed:** the rest now knows which exercise it belongs to (`restExId`, set by `startRest`; `null` for a manually-started rest). Changing that exercise's duration re-anchors on `restStartedAt`, so time already served still counts — 30s into a 2:00 rest, picking 3:00 leaves 2:30, not a fresh 3:00. A duration already spent (or the picker's "Off") ends the rest and cancels its alert. The Live Activity and Watch pick it up from state they already watch. `onWorkoutChanged` now reports `{ seconds, exerciseId }` so the card's ✓ path carries the same ownership.

**Also fixed (the issue asked this be verified):** the in-rest **−15/+15** moved `restEndsAt` but never re-armed the scheduled end-of-rest notification, so it still fired at the *original* moment. All three ±15 surfaces (in-app, card, Watch) now go through one `adjustRest` that re-arms it, writing `restEndsRef` eagerly so a drain of several queued card taps composes instead of each reading the same pre-tick end time.

## #19 — Rest notification named the exercise just finished

**Wrong — and not where the issue expected.** `buildLiveActivityState`'s `next` was already crossing the exercise boundary correctly; I added tests pinning that rather than changing it. The actual defect was in `toggleDone`: it armed the alert with `ex.name`, the exercise of the set *just completed*. Finishing the last set of Squat buzzed "Next set: Squat". Same bug in the Watch's Log Set path. The Live Activity's ✓ path was already correct (it refetches first).

**Changed:** both paths now name the exercise the *next unfinished set* belongs to, passing the completing set as `treatAsDone` because `exercises` has not re-rendered yet.

## #20 — Watch "Next" label stuck inside the current exercise

**Wrong:** `nextSetLabel` read ``Next: Set ${Math.min(index + 2, ex.sets.length)}`` — one set too far, then clamped inside the current exercise. On the last set of an exercise it handed that exercise's own last set number back as "next".

**Changed:** the located set already *is* the upcoming one (during rest the completed set is `done`, so the scan has crossed into the next exercise), so the label is now ``Next: Set ${index + 1} of ${ex.sets.length}`` — the same phrasing as the Lock Screen card's rest subtitle.

**Shared util (#19 + #20):** extracted `src/lib/nextSet.ts` → `locateNextSet(exercises, treatAsDone?)`, pure and tested (12 cases). `liveActivityState.ts`, `watchState.ts` and the workout screen all use it, so phone, card and Watch can no longer disagree.

**Left for the reviewer / a design call:** the Watch's Rest ring shows `nextSetLabel` and *nothing else* — no exercise name anywhere on that screen. So after crossing into a new exercise the user sees the right set number but not which exercise it is for. Fitting a name inside the 116pt ring (11.5pt mono, `lineLimit(1)`) isn't possible without a layout change to `RestView.swift`, which the plan assigns to the #28 watch-rest work. **I stopped rather than invent that layout.**

One test (`the next-set label never runs past the last set`) asserted the clamp — it encoded the bug, so it's replaced with the two rest-time cases it got wrong.

## #21 — Duplicate HKWorkout for Watch-recorded sessions

**Wrong:** the design is that the Watch saves the `HKWorkout` and confirms over WatchConnectivity, and the phone writes only if no confirmation lands within 10s. But the confirmation is not a reliable stand-in for "did not save" — `PhoneLink.send` falls back to `transferUserInfo` whenever the phone app isn't reachable (the usual case when the user ends *from the Watch*), and that is queued until the phone next runs, long past the timeout. `HKWorkoutBuilder.finishWorkout` can outrun it on its own too. Either way the workout is already in Health when the phone writes its copy.

**Changed:** ask HealthKit instead of inferring. New native `hasWorkout(start, end)`; the phone writes only when nothing is there. Also covers a phone-side sync that ran twice for one workout.

The query is deliberately narrow, because a false positive would *drop a real workout* rather than duplicate one:
- only strength workouts whose source bundle id is ours or the Watch companion's (prefix match), so another tracker's overlapping session can't be mistaken for ours;
- only when the overlap covers **at least half of both intervals**, so back-to-back sessions touching at an endpoint don't match.

Anything uncertain — query error, workout-read access denied, an older native module without the query — resolves `false` and writes. That is the previous behaviour: a rare duplicate beats a lost workout.

**Needs device testing:** record with the Watch, end from the Watch (the case that produced the duplicate), confirm exactly one entry in Fitness.

## #29 — Live Activity silently absent

**Confirmed cause (ask 1):** disabled authorization, not a start bug. iOS turns the per-app switch off by itself once a card is dismissed; `Activity.request` then throws and `start()` returns nil. Every path in the screen bailed on `isSupported()`, which conflated *"this iPhone can show Live Activities"* with *"they're enabled for us"* — which is exactly why the state was undiagnosable.

**Changed (ask 2):** added native `isAvailable()` for the OS capability alone. The pair now identifies the actionable case precisely — available but not supported means the user switched them off. On that state the screen shows one alert offering **Settings**, at most once per install; the flag is cleared whenever a card *does* start, so a later switch-off earns one fresh reminder rather than silence forever. An iPhone too old for Live Activities says nothing, since there's nothing to do about it.

Also moved the foreground reconcile's `isSupported()` check *inside* the AppState listener: returning from Settings having just enabled them is itself a foreground transition, and the outer check ran while they were still off and skipped registering the listener at all.

---

# Watch Swift — UNVERIFIED, needs on-device testing

Both are Swift in `frontend/targets/ischys-watch/`, in separate commits. **I cannot run these** — no Xcode/Watch here.

What I *could* verify: `swiftc -parse` clean, and a full `-typecheck` against the iOS SDK produced **no errors in `WorkoutModel.swift`, `ActiveSetView.swift`, or the changed part of `PhoneLink.swift`** (the only errors were `WCSessionDelegate` requiring two extra methods on iOS but not watchOS, and `WorkoutManager` being outside the compile set — both artefacts of the SDK substitution, not the changes). That is a type-check, not a run.

## #32 — Elapsed counted from the Watch session

The elapsed clock counted from the `HKWorkoutSession` start — whenever the Watch app got going, which can be seconds (phone launch) or minutes (user opens it mid-session) after the workout began.

The phone now pushes `startedAt` (epoch ms) in the Watch state; the Watch uses it as the elapsed origin. The session start is only a fallback for the window before the first push, and no longer overwrites a `startedAt` that already arrived. Adopting one updates the clock immediately rather than at the next tick. `0` means "phone doesn't know yet" and is ignored, so a missing value can't park the clock at 1970.

The JS half **is** covered by tests (`startedAt` pushed / 0 when unknown).

**Test on device:** start from the phone, check the Watch's Metrics elapsed matches the phone's; then open the Watch app several minutes into a workout and confirm it shows the real elapsed, not 0:00.

## #30 — Watch ignored phone-side edits mid-set

Two things blocked it, both fixed: `apply` copied `weight`/`reps` only when the exercise or set number changed; and `ActiveSetView` re-seeded the Crown only `.onChange(of: model.setNum)` — the Crown holds its own `Double`, so even once the model updated, the next notch would write the stale value straight back.

`apply` now also takes a pushed edit for the current set and bumps a `valueSeed` counter the view watches instead of `setNum` — one signal covering both "new set" and "phone edited this set".

The exception is a wrist mid-turn: a pushed edit is held while the Crown has moved within the last **3s** and lands once it goes quiet (or immediately on a set change, which resets the grace). The view tells its own re-seed from a real turn with a `seeding` flag, armed only when the seed will actually change the value — otherwise it would swallow the user's next genuine turn.

**Also:** seeding parsed the pushed string with `Double`, which rejects the `"24,8"` a comma-locale phone keyboard produces and dropped the Crown to 0. The separator is normalised first, and a seed no longer rewrites the phone's value through the 0.5 rounding.

**Test on device — this is the one most worth a careful pass.** The 3s grace and the `seeding` flag are timing-sensitive and I could not exercise them:
1. Edit weight on the phone mid-set → Watch should follow within a push.
2. Turn the Crown, and while turning have the phone push a change → the Watch should *not* yank the value away; it should land ~3s after you stop.
3. Turn the Crown, then tick the set off on the phone → new set's values seed immediately, no grace.
4. Comma-locale device: confirm a `24,8` weight seeds the Crown to 24.8, not 0.

---

## Left undone / for the owner

- **#20's Watch Rest screen doesn't name the upcoming exercise** — needs a `RestView.swift` layout decision (see above). Deliberately not invented.
- Build number not bumped, nothing archived or submitted, nothing deployed.
- `.wrangler/` and `targets/ischys-watch/Assets.xcassets/` were already untracked before this work and are left alone.
